### PR TITLE
Enable GPU acceleration when rendering

### DIFF
--- a/utils/utils.py
+++ b/utils/utils.py
@@ -118,7 +118,18 @@ def set_cycles_renderer(scene: bpy.types.Scene,
     scene.view_layers[0].cycles.use_denoising = use_denoising
 
     scene.cycles.samples = num_samples
+    
+    # Enable GPU Acceleration 
+    # Source - https://blender.stackexchange.com/a/196702
+    bpy.context.scene.cycles.device = "GPU"
+    bpy.context.preferences.addons["cycles"].preferences.compute_device_type = "CUDA"
 
+    # get_devices() to let Blender detects GPU device
+    bpy.context.preferences.addons["cycles"].preferences.get_devices()
+    print(bpy.context.preferences.addons["cycles"].preferences.compute_device_type)
+    for d in bpy.context.preferences.addons["cycles"].preferences.devices:
+        d["use"] = 1 # Using all devices, include GPU and CPU
+        print(d["name"], d["use"])
 
 ################################################################################
 # Constraints


### PR DESCRIPTION
The added code blocks let blender leverage the GPU if available. (Code Source - https://blender.stackexchange.com/a/196702)

Running 10_mocap.py with resolution 100, samplings 128, and rendering single frame 
without GPU - Time: 01:57.42 (Saving: 00:00.37) 
with GPU -      Time: 00:35.81 (Saving: 00:00.36)
          CUDA
          GeForce GTX TITAN X (Display) 1
          Intel Core i7-5930K CPU @ 3.50GHz 1

Much faster!