### PR TITLE
Option to change output resolution

### DIFF
--- a/utils/utils.py
+++ b/utils/utils.py
@@ -95,8 +95,10 @@ def build_environment_texture_background(world: bpy.types.World, hdri_path: str,
     arrange_nodes(node_tree)
 
 
-def set_output_properties(scene: bpy.types.Scene, resolution_percentage: int = 100, output_file_path: str = "") -> None:
+def set_output_properties(scene: bpy.types.Scene, resolution_percentage: int = 100, output_file_path: str = "", res_x: int = 1920, res_y: int = 1080) -> None:
     scene.render.resolution_percentage = resolution_percentage
+    scene.render.resolution_x = res_x
+    scene.render.resolution_y = res_y
 
     if output_file_path:
         scene.render.filepath = output_file_path


### PR DESCRIPTION
current rendering is set to scene's default values of 1920, 1080.
To change to portrait or square images, very useful to fit rendering to subject. 
scene.render.resolution_(x or y) can be used to change the resolution of the output as required.